### PR TITLE
Seed filtering with KDE

### DIFF
--- a/src/ct_plotting/data.py
+++ b/src/ct_plotting/data.py
@@ -324,7 +324,7 @@ class Genotype(Seed_Container):
         if sorted_zs[0] > 100:
             return
 
-        kde = KernelDensity(bandwidth=10).fit(sorted_zs)
+        kde = KernelDensity(bandwidth=20).fit(sorted_zs)
         xs = np.linspace(0, max(sorted_zs), 1000)
         score = kde.score_samples(xs)
 

--- a/src/ct_plotting/data.py
+++ b/src/ct_plotting/data.py
@@ -329,13 +329,17 @@ class Genotype(Seed_Container):
         score = kde.score_samples(xs)
 
         peaks, _ = find_peaks(score * -1)
-        cutoff = xs[min(peaks)]
 
-        for plant in self.plants:
-            for pod in plant.pods:
-                pod.seeds = [
-                    seed for seed in pod.seeds if pod._real_z(seed) > cutoff
-                ]
+        if len(peaks) > 0:
+            cutoff = xs[min(peaks)]
+
+            for plant in self.plants:
+                for pod in plant.pods:
+                    pod.seeds = [
+                        seed
+                        for seed in pod.seeds
+                        if pod._real_z(seed) > cutoff
+                    ]
 
 
 class Seed:

--- a/src/ct_plotting/data.py
+++ b/src/ct_plotting/data.py
@@ -328,7 +328,7 @@ class Genotype(Seed_Container):
         xs = np.linspace(0, max(sorted_zs), 1000)
         score = kde.score_samples(xs)
 
-        peaks, _ = find_peaks(score * -1)
+        peaks, _ = find_peaks(score * -1, height=10)
 
         if len(peaks) > 0:
             cutoff = xs[min(peaks)]

--- a/src/ct_plotting/data.py
+++ b/src/ct_plotting/data.py
@@ -3,6 +3,8 @@ import math
 
 import numpy as np
 from scipy import integrate
+from scipy.signal import find_peaks
+from sklearn.neighbors import KernelDensity
 
 
 def _list_of_props(containers, fn):
@@ -316,6 +318,24 @@ class Genotype(Seed_Container):
             vs += plant.seed_spacings()
 
         return vs
+
+    def filter(self):
+        sorted_zs = np.sort(np.array(self.real_zs())).reshape(-1, 1)
+        if sorted_zs[0] > 100:
+            return
+
+        kde = KernelDensity(bandwidth=10).fit(sorted_zs)
+        xs = np.linspace(0, max(sorted_zs), 1000)
+        score = kde.score_samples(xs)
+
+        peaks, _ = find_peaks(score * -1)
+        cutoff = xs[min(peaks)]
+
+        for plant in self.plants:
+            for pod in plant.pods:
+                pod.seeds = [
+                    seed for seed in pod.seeds if pod._real_z(seed) > cutoff
+                ]
 
 
 class Seed:


### PR DESCRIPTION
Filter seeds by finding a local minimum in the kernel density estimation.  The first local minimum represents the boundary between the noise at the beak and the real data.

A maximum log KDE of -10 is imposed as otherwise the algorithm will filter real seeds in the case where there is no beak noise.